### PR TITLE
`querySync` operator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,5 @@ export * from './utils/build-path';
 export * from './methods/is-route';
 export * from './methods/redirect';
 export * from './methods/chain-route';
+export * from './methods/query-sync';
 export * from './types';

--- a/src/methods/query-sync.ts
+++ b/src/methods/query-sync.ts
@@ -1,0 +1,42 @@
+import { Clock, combine, createStore, sample, Store, Unit } from 'effector';
+
+import { RouteInstance, RouteQuery } from '../types';
+import { createRouterControls } from './create-router-controls';
+
+type QuerySyncParams<T extends Record<string, Store<any>>> = {
+  source: T;
+  clock?: Clock<any>;
+  controls: ReturnType<typeof createRouterControls>;
+  route?: RouteInstance<any>;
+};
+
+export function querySync<T extends Record<string, Store<any>>>(
+  params: QuerySyncParams<T>
+) {
+  const $isOpened = params.route?.$isOpened ?? createStore(true);
+  const $source = combine(params.source);
+  const clock = (params.clock ?? $source) as Unit<any>;
+
+  const queryUpdated = sample({
+    clock: params.controls.$query,
+    filter: $isOpened,
+  });
+
+  sample({
+    clock,
+    source: combine([$source, params.controls.$query]),
+    filter: $isOpened,
+    fn: ([source, currentQuery]) => {
+      return { ...currentQuery, ...source } as RouteQuery;
+    },
+    target: params.controls.$query,
+  });
+
+  for (const k in params.source) {
+    const $queryParam = params.source[k as keyof typeof params.source];
+
+    $queryParam.on(queryUpdated, (_, query) => {
+      return query[k] ?? $queryParam.defaultState;
+    });
+  }
+}

--- a/src/methods/query-sync.ts
+++ b/src/methods/query-sync.ts
@@ -3,11 +3,18 @@ import { Clock, combine, createStore, sample, Store, Unit } from 'effector';
 import { RouteInstance, RouteQuery } from '../types';
 import { createRouterControls } from './create-router-controls';
 
+type QueryCleanupStrategy = {
+  irrelevant: boolean;
+  empty: boolean;
+  preserve: string[];
+};
+
 type QuerySyncParams<T extends Record<string, Store<any>>> = {
   source: T;
   clock?: Clock<any>;
   controls: ReturnType<typeof createRouterControls>;
   route?: RouteInstance<any>;
+  cleanup?: boolean | Partial<QueryCleanupStrategy>;
 };
 
 export function querySync<T extends Record<string, Store<any>>>(
@@ -16,8 +23,13 @@ export function querySync<T extends Record<string, Store<any>>>(
   const $isOpened = params.route?.$isOpened ?? createStore(true);
   const $source = combine(params.source);
   const clock = (params.clock ?? $source) as Unit<any>;
+  const cleanupStrategy = !('cleanup' in params)
+    ? cleanupStrategies.default
+    : typeof params.cleanup === 'boolean'
+    ? cleanupStrategies[params.cleanup ? 'all' : 'none']
+    : { ...cleanupStrategies.default, ...params.cleanup! };
 
-  const queryUpdated = sample({
+  const queryUpdatedFromHistory = sample({
     clock: params.controls.$query,
     filter: $isOpened,
   });
@@ -27,16 +39,53 @@ export function querySync<T extends Record<string, Store<any>>>(
     source: combine([$source, params.controls.$query]),
     filter: $isOpened,
     fn: ([source, currentQuery]) => {
-      return { ...currentQuery, ...source } as RouteQuery;
+      let nextQuery: RouteQuery = {};
+      if (cleanupStrategy.irrelevant) {
+        for (const key of cleanupStrategy.preserve) {
+          if (key in currentQuery) {
+            nextQuery[key] = currentQuery[key];
+          }
+        }
+      } else {
+        nextQuery = { ...currentQuery };
+      }
+      for (const key in source) {
+        nextQuery[key] = source[key];
+      }
+      if (cleanupStrategy.empty) {
+        for (const key in source) {
+          if (!cleanupStrategy.preserve.includes(key) && !nextQuery[key]) {
+            delete nextQuery[key];
+          }
+        }
+      }
+      return nextQuery as RouteQuery;
     },
     target: params.controls.$query,
   });
 
   for (const k in params.source) {
     const $queryParam = params.source[k as keyof typeof params.source];
-
-    $queryParam.on(queryUpdated, (_, query) => {
+    $queryParam.on(queryUpdatedFromHistory, (_, query) => {
       return query[k] ?? $queryParam.defaultState;
     });
   }
 }
+
+const cleanupStrategies = {
+  all: {
+    irrelevant: true,
+    empty: true,
+    preserve: [],
+  },
+  default: {
+    irrelevant: false,
+    empty: true,
+    preserve: [],
+  },
+  none: {
+    irrelevant: false,
+    empty: false,
+    preserve: [],
+  },
+};

--- a/test/query-sync.test.ts
+++ b/test/query-sync.test.ts
@@ -1,0 +1,174 @@
+import { createMemoryHistory } from 'history';
+import { describe, it, expect } from 'vitest';
+import { allSettled, createEvent, createStore, fork, restore } from 'effector';
+
+import {
+  createRoute,
+  createHistoryRouter,
+  querySync,
+  createRouterControls,
+} from '../src';
+
+const route = createRoute();
+const notOpenedRoute = createRoute();
+
+const controls = createRouterControls();
+
+const router = createHistoryRouter({
+  routes: [
+    { path: '/', route },
+    { path: '/not-opened', route: notOpenedRoute },
+  ],
+  controls,
+});
+
+describe('querySync', () => {
+  it('Updates query when source is changed', async () => {
+    const qChanged = createEvent<string>();
+    const $q = restore(qChanged, '');
+
+    querySync({
+      source: { q: $q },
+      controls,
+    });
+
+    const scope = fork();
+    const history = createMemoryHistory();
+    await allSettled(router.setHistory, {
+      scope,
+      params: history,
+    });
+    await allSettled(qChanged, {
+      scope,
+      params: 'test',
+    });
+
+    expect(scope.getState(controls.$query)).toEqual({
+      q: 'test',
+    });
+    expect(history.location.search).toEqual(`?q=test`);
+  });
+
+  it('Updates source when query is changed', async () => {
+    const $q = createStore('');
+
+    querySync({
+      source: { q: $q },
+      controls,
+    });
+
+    const scope = fork();
+    const history = createMemoryHistory();
+    await allSettled(router.setHistory, {
+      scope,
+      params: history,
+    });
+    history.push('/?q=foo');
+
+    expect(scope.getState($q)).toEqual('foo');
+  });
+
+  it('Sets source to defaultState if query param is missing', async () => {
+    const qChanged = createEvent<string>();
+    const $q = createStore('defaultState');
+
+    $q.on(qChanged, (prev, next) => next);
+
+    querySync({
+      source: { q: $q },
+      controls,
+    });
+
+    const scope = fork();
+    const history = createMemoryHistory();
+    await allSettled(router.setHistory, {
+      scope,
+      params: history,
+    });
+    await allSettled(qChanged, {
+      scope,
+      params: 'foo',
+    });
+    history.push('/?foo=test');
+
+    expect(scope.getState($q)).toEqual('defaultState');
+  });
+
+  it('Ignore source updates if passed route is not opened', async () => {
+    const qChanged = createEvent<string>();
+    const $q = restore(qChanged, '');
+
+    querySync({
+      source: { q: $q },
+      controls,
+      route: notOpenedRoute,
+    });
+
+    const scope = fork();
+    const history = createMemoryHistory();
+    await allSettled(router.setHistory, {
+      scope,
+      params: history,
+    });
+    await allSettled(qChanged, {
+      scope,
+      params: 'test',
+    });
+
+    expect(history.location.search).toEqual('');
+  });
+
+  it('Ignore history updates if passed route is not opened', async () => {
+    const $q = createStore('');
+
+    querySync({
+      source: { q: $q },
+      controls,
+      route: notOpenedRoute,
+    });
+
+    const scope = fork();
+    const history = createMemoryHistory();
+    await allSettled(router.setHistory, {
+      scope,
+      params: history,
+    });
+    history.push('/?foo=bar');
+
+    expect(scope.getState($q)).toEqual('');
+  });
+
+  it('Triggers history updates only on `clock` trigger (if present)', async () => {
+    const qChanged = createEvent<string>();
+    const clock = createEvent();
+    const $q = restore(qChanged, '');
+
+    querySync({
+      source: { q: $q },
+      clock,
+      controls,
+    });
+
+    const scope = fork();
+    const history = createMemoryHistory();
+    await allSettled(router.setHistory, {
+      scope,
+      params: history,
+    });
+    await allSettled(qChanged, {
+      scope,
+      params: 'test',
+    });
+    await allSettled(qChanged, {
+      scope,
+      params: 'bar',
+    });
+
+    expect(history.location.search).toEqual('');
+
+    await allSettled(clock, {
+      scope,
+    });
+    expect(history.location.search).toEqual('?q=bar');
+  });
+});


### PR DESCRIPTION
## What is it?
In **v0.7.0** we introduced `createRouterControls` which allows to update `controls.$query` store directly and sync it with URL

But if we want to sync query with some other stores (e.g. search input), it's gonna be a lot of boilerplate.

This PR introduces new operator - `querySync`. It does all the work for you

## Use cases

### Search page
```tsx
import { querySync } from 'atomic-router'

const searchRoute = createRoute()

const $q = createStore("")

querySync({
  source: { q: $q },
  route: searchRoute, 
  controls
})
```
Here we
- Automatically fill `$q` store with `q` query param if route is changed
- Update query string when `$q` is changed  

Since we also passed `route` param, this sync will only work when `searchRoute.$isOpened` is `true`

### Global query parameters like utm-marks

If we need to get a parameter from any page, we can skip `route`

```tsx
const $utmSource = createStore('')

querySync({
  source: { 
    utm_source: $utmSource 
  }, 
  controls
})
```

### Debounced updates?

If we don't want to spam route updates, there's a `clock` parameter, which will update route only when it's triggered

```tsx
const canvasEditorRoute = createRoute()

const canvasDragged = createEvent()
const canvasDragEnded = createEvent()

const $x = createStore('0')
const $y = createStore('0')

querySync({
  source: { x: $x, y: $y },
  route: canvasEditorRoute,
  clock: canvasDragEnded, 
  controls
})
```