### PR TITLE
Remove warning for scope-less runtime

### DIFF
--- a/src/methods/new-create-history-router.ts
+++ b/src/methods/new-create-history-router.ts
@@ -101,9 +101,7 @@ export function createHistoryRouter({
       try {
         // @ts-expect-error
         scopedHistoryUpdated = scopeBind(historyUpdated);
-      } catch (err) {
-        console.log(err);
-      }
+      } catch (err) {}
       history.listen(() => {
         scopedHistoryUpdated();
       });


### PR DESCRIPTION
This warning is meaningless for application without scope, so in my mind it's better to remove it.