### PR TITLE
Better typings for .open()

### DIFF
--- a/src/methods/create-route.ts
+++ b/src/methods/create-route.ts
@@ -13,6 +13,7 @@ import {
   RouteInstance,
   NavigateParams,
   Kind,
+  EmptyObject,
 } from '../types';
 
 type CreateRouteParams = {
@@ -33,8 +34,8 @@ export function createRoute<Params extends RouteParams = {}>(
 
   const openFx = attach({
     effect: navigateFx,
-    mapParams: (params: Params) => ({
-      params: params || ({} as Params),
+    mapParams: (params: Params extends EmptyObject ? void : Params) => ({
+      params: (params || {}) as Params,
       query: {} as RouteQuery,
     }),
   });

--- a/src/methods/redirect.ts
+++ b/src/methods/redirect.ts
@@ -7,11 +7,9 @@ import {
   sample,
   Store,
 } from 'effector';
-import { RouteInstance, RouteParams, RouteQuery } from '../types';
+import { EmptyObject, RouteInstance, RouteParams, RouteQuery } from '../types';
 
-type RedirectParams<T, Params extends RouteParams> = Params extends {
-  [key in string]: never;
-}
+type RedirectParams<T, Params extends RouteParams> = Params extends EmptyObject
   ? {
       clock?: Clock<T>;
       route: RouteInstance<Params>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,10 @@ export type RouteInstance<Params extends RouteParams> = {
   updated: Event<RouteParamsAndQuery<Params>>;
   closed: Event<void>;
   navigate: Effect<NavigateParams<Params>, NavigateParams<Params>>;
-  open: Effect<Params, RouteParamsAndQuery<Params>>;
+  open: Effect<
+    Params extends EmptyObject ? void : Params,
+    RouteParamsAndQuery<Params>
+  >;
   kind: typeof Kind.ROUTE;
 };
 
@@ -58,3 +61,5 @@ export type PathCreator<Params extends RouteParams> = string;
 export const Kind = {
   ROUTE: Symbol(),
 };
+
+export type EmptyObject = { [key in string]: never };


### PR DESCRIPTION
Don't require params for route.open() if the route has no params

This change doesn't affect implementation but allows us to not pass empty object in open() if route doesn't have params. Params still will be available everywhere (opened, updated events, open result, etc) therefore this change has full backward compatibility

Closes #1 