### PR TITLE
Add `replace` option for `redirect` operator

### DIFF
--- a/src/methods/redirect.ts
+++ b/src/methods/redirect.ts
@@ -14,6 +14,7 @@ type RedirectParams<T, Params extends RouteParams> = Params extends EmptyObject
       clock?: Clock<T>;
       route: RouteInstance<Params>;
       query?: ((clock: T) => RouteQuery) | Store<RouteQuery> | RouteQuery;
+      replace?: ((clock: T) => boolean) | Store<boolean> | boolean;
     }
   :
       | {
@@ -21,15 +22,18 @@ type RedirectParams<T, Params extends RouteParams> = Params extends EmptyObject
           route: RouteInstance<Params>;
           params: ((clock: T) => Params) | Store<Params> | Params;
           query?: ((clock: T) => RouteQuery) | Store<RouteQuery> | RouteQuery;
+          replace?: ((clock: T) => boolean) | Store<boolean> | boolean;
         }
       | {
           clock?: Clock<{
             params: Params;
             query?: RouteQuery;
+            replace?: boolean;
           }>;
           route: RouteInstance<Params>;
           params?: ((clock: T) => Params) | Store<Params> | Params;
           query?: ((clock: T) => RouteQuery) | Store<RouteQuery> | RouteQuery;
+          replace?: ((clock: T) => boolean) | Store<boolean> | boolean;
         };
 
 /** Opens passed `route` upon `clock` trigger */
@@ -42,13 +46,16 @@ export function redirect<T, Params extends RouteParams>(
 
   let params = toStore(options.params || {});
   let query = toStore(options.query || {});
+  // @ts-expect-error
+  let replace = toStore(options.replace || false);
 
   sample({
     clock: clock,
-    source: { params, query },
-    fn: ({ params, query }, clock) => ({
+    source: { params, query, replace },
+    fn: ({ params, query, replace }, clock) => ({
       params: typeof params === 'function' ? params(clock) : params,
       query: typeof query === 'function' ? query(clock) : query,
+      replace: typeof replace === "function" ? replace(clock) : replace,
     }),
     target: options.route.navigate,
   });

--- a/test/redirect.test.ts
+++ b/test/redirect.test.ts
@@ -1,4 +1,4 @@
-import { allSettled, createEvent, createStore, fork } from 'effector';
+import {allSettled, createEvent, createStore, fork, restore} from 'effector';
 import { describe, it, expect, vi } from 'vitest';
 import { createHistoryRouter, createRoute, redirect } from '../src';
 import { createMemoryHistory } from 'history';
@@ -158,4 +158,64 @@ describe('redirect', () => {
       baz: 'bar-test',
     });
   });
+
+
+  describe('`replace` option', () => {
+    it('primitive variant', async () => {
+      const clock = createEvent();
+      const route = createRoute();
+      const $navigateDone = restore(route.navigate.done, null)
+
+      redirect({
+        clock,
+        route,
+        replace: true,
+      });
+
+      const scope = fork();
+
+      await allSettled(clock, { scope });
+
+      expect(scope.getState($navigateDone)).toBeTruthy();
+      expect(scope.getState($navigateDone.map(data => data?.params.replace))).toEqual(true);
+    });
+
+    it('store variant', async () => {
+      const clock = createEvent();
+      const route = createRoute();
+      const $navigateDone = restore(route.navigate.done, null)
+
+      redirect({
+        clock,
+        route,
+        replace: createStore(true),
+      });
+
+      const scope = fork();
+
+      await allSettled(clock, { scope });
+
+      expect(scope.getState($navigateDone)).toBeTruthy();
+      expect(scope.getState($navigateDone.map(data => data?.params.replace))).toEqual(true);
+    });
+
+    it('fn variant', async () => {
+      const clock = createEvent();
+      const route = createRoute();
+      const $navigateDone = restore(route.navigate.done, null)
+
+      redirect({
+        clock,
+        route,
+        replace: () => true,
+      });
+
+      const scope = fork();
+
+      await allSettled(clock, { scope });
+
+      expect(scope.getState($navigateDone)).toBeTruthy();
+      expect(scope.getState($navigateDone.map(data => data?.params.replace))).toEqual(true);
+    });
+  })
 });


### PR DESCRIPTION
This PR provides the ability for sending "replace" for navigating routes with using "redirect" method

Sorry for creating [duplicate PRs](https://github.com/atomic-router/atomic-router/pull/53) but that feature is really needed for my work   
