### PR TITLE
Added re-export of the RouteObjectInternal type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export type {
   RouteParamsAndQuery,
   RouteInstance,
   RouteObject,
+  RouteObjectInternal,
   UnmappedRouteObject,
   HistoryBackForwardParams,
   HistoryPushParams,


### PR DESCRIPTION
In a TS project, when trying to export a router instance, typescript throws the error [TS4023](https://github.com/microsoft/TypeScript/issues/5711). 

I'm not entirely sure this is the correct solution, as in my own project, I resolved the issue by directly adding the missing export to the atomic-router.d.mts file.